### PR TITLE
Improvements

### DIFF
--- a/CucumberFeatureAutocomplete.py
+++ b/CucumberFeatureAutocomplete.py
@@ -131,7 +131,7 @@ class CucumberFeatureAutocomplete(sublime_plugin.EventListener):
         unbraced_chunks = re.split('(\([^?:][^())]*\))', completion)
         try:
             for i in range(0, len(unbraced_chunks)):
-                if i%2 == 1:
+                if i%2 == 1 and not re.match(r'\([\w \|]+\)', unbraced_chunks[i]):
                     unbraced_chunks[i] = '('+field_chunks[(i-1)//2]+')'
             return "".join(map("".join, unbraced_chunks))
         except:

--- a/CucumberFeatureAutocomplete.py
+++ b/CucumberFeatureAutocomplete.py
@@ -126,39 +126,18 @@ class CucumberFeatureAutocomplete(sublime_plugin.EventListener):
         them together
         """
         fields = fields.replace('|', '').replace('$', '$$')
-        params = [x for x in re.split(',', fields)]
+        params = [x.strip() for x in re.split(',', fields)]
         field_chunks = [re.split(' ', x)[-1] for x in params]
+        unbraced_chunks = re.split('(\([^?:][^())]*\))', completion)
         try:
-            zipped = zip_longest(
-                self.unbraced_chunks(completion),
-                field_chunks,
-                fillvalue="")
-            return "".join(map("".join, zipped))
+            for i in range(0, len(unbraced_chunks)):
+                if i%2 == 1:
+                    unbraced_chunks[i] = '('+field_chunks[(i-1)//2]+')'
+            return "".join(map("".join, unbraced_chunks))
         except:
             log.exception("failed completion: {0} fields: {1}".format(
                 completion, fields))
             return completion
-
-    def unbraced_chunks(self, txt):
-        """Split regex into list around the capturing groups
-        """
-        chunk = ''
-        depth = 0
-        for idx, char in enumerate(txt):
-            if char == '(':
-                if (txt[idx+1] != '?' and txt[idx+2] != ':'):
-                    if depth == 0:
-                        yield chunk
-                        chunk = ''
-                    depth = depth + 1
-                else:
-                    chunk = chunk + char
-            elif char == ')' and depth > 0:
-                depth = depth - 1
-            elif depth == 0:
-                chunk = chunk + char
-        yield chunk
-
 
 class CucumberCompletionResetStepFoldersCommand(sublime_plugin.WindowCommand):
     

--- a/CucumberFeatureAutocomplete.py
+++ b/CucumberFeatureAutocomplete.py
@@ -16,7 +16,6 @@ ruby_regexp = re.compile(r'[/"]\^?\(?(.*?)\$?[/"]\)? do(.*)')
 groovy_regexp = re.compile(r"[/'\"]\^?(.*?)\$?[/'\"]\) \{ (.*?) ?->")
 step_def_regexps = {'groovy': groovy_regexp, 'rb': ruby_regexp}
 suffixes = ['steps.{0}'.format(k) for k in step_def_regexps.keys()]
-step_folder = 'step_definitions'
 step_folders = []
 log = logging.getLogger(__name__)
 
@@ -112,14 +111,13 @@ class CucumberFeatureAutocomplete(sublime_plugin.EventListener):
     def find_step_files(self, base_folders):
         for base in base_folders:
             for (path, dirs, files) in os.walk(base):
-                if (path.endswith(step_folder)):
-                    if not (path in step_folders):
-                        step_folders.append(path)
-                    for file_name in files:
-                        if any(file_name.lower().endswith(s) for s in suffixes):
-                            log.debug("found: " + file_name)
-                            with open(os.path.join(path, file_name)) as f:
-                                yield f, file_name
+                for file_name in files:
+                    if any(file_name.lower().endswith(s) for s in suffixes):
+                        if not (path in step_folders):
+                            step_folders.append(path)
+                        log.debug("found: " + file_name)
+                        with open(os.path.join(path, file_name)) as f:
+                            yield f, file_name
 
     def create_completion_text(self, completion, fields):
         """Create human readable text from the step regular expression
@@ -160,3 +158,13 @@ class CucumberFeatureAutocomplete(sublime_plugin.EventListener):
             elif depth == 0:
                 chunk = chunk + char
         yield chunk
+
+
+class CucumberCompletionResetStepFoldersCommand(sublime_plugin.WindowCommand):
+    
+    def __init__(self, window):
+        sublime_plugin.WindowCommand.__init__(self, window)
+
+    def run(self):
+        global step_folders
+        step_folders = []

--- a/CucumberFeatureAutocomplete.py
+++ b/CucumberFeatureAutocomplete.py
@@ -12,7 +12,7 @@ except:
 
 thing = ''
 step_def_urls = []
-ruby_regexp = re.compile(r'[/"]\^?\(?(.*?)\$?[/"]\)? do(.*)')
+ruby_regexp = re.compile(r'[/"]\(?\^?(.*?)\$?[/"]\)? do(.*)')
 groovy_regexp = re.compile(r"[/'\"]\^?(.*?)\$?[/'\"]\) \{ (.*?) ?->")
 step_def_regexps = {'groovy': groovy_regexp, 'rb': ruby_regexp}
 suffixes = ['steps.{0}'.format(k) for k in step_def_regexps.keys()]

--- a/CucumberFeatureAutocomplete.sublime-commands
+++ b/CucumberFeatureAutocomplete.sublime-commands
@@ -1,3 +1,3 @@
 [
-	{ "command" : "cucumber_completion_reset_step_folders", "caption": "Cucumber Completion: Reset step folders in cache" }
+	{ "command" : "cucumber_completion_reset_step_folders", "caption": "Cucumber Completion: Reset cached step folders" }
 ]

--- a/CucumberFeatureAutocomplete.sublime-commands
+++ b/CucumberFeatureAutocomplete.sublime-commands
@@ -1,0 +1,3 @@
+[
+	{ "command" : "cucumber_completion_reset_step_folders", "caption": "Cucumber Completion: Reset step folders in cache" }
+]

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,3 @@
+[
+  { "keys": ["ctrl+shift+f5"], "command": "cucumber_completion_reset_step_folders" }
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,3 @@
+[
+  { "keys": ["ctrl+super+f5"], "command": "cucumber_completion_reset_step_folders" }
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,3 @@
+[
+  { "keys": ["ctrl+shift+f5"], "command": "cucumber_completion_reset_step_folders" }
+]

--- a/examples/groovy-calculator.expected
+++ b/examples/groovy-calculator.expected
@@ -1,3 +1,3 @@
-I have entered number into ignore calculator
-I press opname
-the stored result should be expected
+I have entered (number) into (ignore) calculator
+I press (opname)
+the stored result should be (expected)

--- a/examples/test_unit.expected
+++ b/examples/test_unit.expected
@@ -1,2 +1,2 @@
-var = value
-I can assert that var_a == var_b
+(var) = (value)
+I can assert that (var_a) == (var_b)

--- a/test/test_cucumber_completion.py
+++ b/test/test_cucumber_completion.py
@@ -40,3 +40,7 @@ def test_splitting_regex_by_groups():
 def test_splitting_regex_ignores_outer_braces():
     chunks = completer.create_completion_text('More (braces (arent)) groups', 'group1')
     assert 'More (braces (group1)) groups' == chunks
+
+def test_splitting_regex_non_catching_groups():
+    chunks = completer.create_completion_text('This sentence contains(?: non catched (.*)) group', 'group1')
+    assert 'This sentence contains(?: non catched (group1)) group'

--- a/test/test_cucumber_completion.py
+++ b/test/test_cucumber_completion.py
@@ -34,7 +34,7 @@ def test_splitting_regex_by_groups():
     chunks = completer.create_completion_text('Mrs (.*) is a customer', 'group1')
     assert 'Mrs (group1) is a customer' == chunks
     chunks = completer.create_completion_text('(Mr|Mrs|Ms) (.*) is a customer', 'group1, group2')
-    assert '(group1) (group2) is a customer' == chunks
+    assert '(Mr|Mrs|Ms) (group2) is a customer' == chunks
 
 
 def test_splitting_regex_ignores_outer_braces():

--- a/test/test_cucumber_completion.py
+++ b/test/test_cucumber_completion.py
@@ -38,7 +38,7 @@ def test_splitting_regex_by_groups():
 
 
 def test_splitting_regex_ignores_outer_braces():
-    chunks = completer.create_completion_text('More (braces (arent)) groups', 'group1')
+    chunks = completer.create_completion_text('More (braces (.*)) groups', 'group1')
     assert 'More (braces (group1)) groups' == chunks
 
 def test_splitting_regex_non_catching_groups():

--- a/test/test_cucumber_completion.py
+++ b/test/test_cucumber_completion.py
@@ -25,18 +25,18 @@ def check_examples(d):
 
 
 def test_splitting_regex_by_no_groups():
-    assert list(completer.create_completion_text("no groups", [])) == ["no groups"]
+    assert list(completer.create_completion_text("no groups", '')) == ["no groups"]
 
 
 def test_splitting_regex_by_groups():
-    chunks = list(completer.create_completion_text('The customers name is (.*)', ['group1']))
+    chunks = list(completer.create_completion_text('The customers name is (.*)', 'group1'))
     assert 'The customers name is (group1)'
-    chunks = list(completer.create_completion_text('Mrs (.*) is a customer', ['group1']))
+    chunks = list(completer.create_completion_text('Mrs (.*) is a customer', 'group1'))
     assert 'Mrs (group1) is a customer' == chunks
-    chunks = list(completer.create_completion_text('(Mr|Mrs|Ms) (.*) is a customer', ['group1', 'group2']))
+    chunks = list(completer.create_completion_text('(Mr|Mrs|Ms) (.*) is a customer', 'group1, group2'))
     assert '(group1) (group2) is a customer' == chunks
 
 
 def test_splitting_regex_ignores_outer_braces():
-    chunks = list(completer.create_completion_text('More (braces (arent)) groups', ['group1']))
+    chunks = list(completer.create_completion_text('More (braces (arent)) groups', 'group1'))
     assert ['More (braces (group1)) groups'] == chunks

--- a/test/test_cucumber_completion.py
+++ b/test/test_cucumber_completion.py
@@ -25,18 +25,18 @@ def check_examples(d):
 
 
 def test_splitting_regex_by_no_groups():
-    assert list(completer.create_completion_text("no groups", '')) == ["no groups"]
+    assert completer.create_completion_text("no groups", '') == "no groups"
 
 
 def test_splitting_regex_by_groups():
-    chunks = list(completer.create_completion_text('The customers name is (.*)', 'group1'))
-    assert 'The customers name is (group1)'
-    chunks = list(completer.create_completion_text('Mrs (.*) is a customer', 'group1'))
+    chunks = completer.create_completion_text('The customers name is (.*)', 'group1')
+    assert 'The customers name is (group1)' == chunks
+    chunks = completer.create_completion_text('Mrs (.*) is a customer', 'group1')
     assert 'Mrs (group1) is a customer' == chunks
-    chunks = list(completer.create_completion_text('(Mr|Mrs|Ms) (.*) is a customer', 'group1, group2'))
+    chunks = completer.create_completion_text('(Mr|Mrs|Ms) (.*) is a customer', 'group1, group2')
     assert '(group1) (group2) is a customer' == chunks
 
 
 def test_splitting_regex_ignores_outer_braces():
-    chunks = list(completer.create_completion_text('More (braces (arent)) groups', 'group1'))
-    assert ['More (braces (group1)) groups'] == chunks
+    chunks = completer.create_completion_text('More (braces (arent)) groups', 'group1')
+    assert 'More (braces (group1)) groups' == chunks

--- a/test/test_cucumber_completion.py
+++ b/test/test_cucumber_completion.py
@@ -25,18 +25,18 @@ def check_examples(d):
 
 
 def test_splitting_regex_by_no_groups():
-    assert list(completer.unbraced_chunks("no groups")) == ["no groups"]
+    assert list(completer.create_completion_text("no groups", [])) == ["no groups"]
 
 
 def test_splitting_regex_by_groups():
-    chunks = list(completer.unbraced_chunks('The customers name is (.*)'))
-    assert ['The customers name is ', ''] == chunks
-    chunks = list(completer.unbraced_chunks('Mrs (.*) is a customer'))
-    assert ['Mrs ', ' is a customer'] == chunks
-    chunks = list(completer.unbraced_chunks('(Mr|Mrs|Ms) (.*) is a customer'))
-    assert ['', ' ', ' is a customer'] == chunks
+    chunks = list(completer.create_completion_text('The customers name is (.*)', ['group1']))
+    assert 'The customers name is (group1)'
+    chunks = list(completer.create_completion_text('Mrs (.*) is a customer', ['group1']))
+    assert 'Mrs (group1) is a customer' == chunks
+    chunks = list(completer.create_completion_text('(Mr|Mrs|Ms) (.*) is a customer', ['group1', 'group2']))
+    assert '(group1) (group2) is a customer' == chunks
 
 
-def test_splitting_regex_ignores_inner_braces():
-    chunks = list(completer.unbraced_chunks('More (braces (arent)) groups'))
-    assert ['More ', ' groups'] == chunks
+def test_splitting_regex_ignores_outer_braces():
+    chunks = list(completer.create_completion_text('More (braces (arent)) groups', ['group1']))
+    assert ['More (braces (group1)) groups'] == chunks


### PR DESCRIPTION
- Improve performance by performing os.walk only on first call on all folders. Next calls will performs os.walk only on folders containing step definitions from previous call.
- Due to improvement, add command to reset cached step definitions in case a folder is added in the view (shortcut : ctrl + shift + f5)
- Improve ruby regexp
